### PR TITLE
still not compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,14 @@ NAME=clarinet
 TARGDIR=./pd-linux
 
 # where to install	### EDIT! ###
-INSTDIR=/usr/lib/pd/extra
+INSTDIR=/Applications/Pd.app/Contents/Resources/extra/
 
 # flext stuff  ### EDIT! ###
 FLEXTPATH=/usr/local/include/flext
 FLEXTLIB=/usr/local/lib/libflext-pd_s.a
 
 # compiler+linker stuff	### EDIT! ###
-INCLUDES=/usr/lib/pd/include
+INCLUDES=/Applications/Pd.app/Contents/Resources/include/
 FLAGS=-DPD
 CFLAGS=-O3 -DPD -DUNIX -DMACOSX -O3 \
     -Wall -W -Wstrict-prototypes \

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 NAME=clarinet
 
 # where to build
-TARGDIR=./pd-linux
+TARGDIR=./pd-darwin
 
 # where to install	### EDIT! ###
 INSTDIR=/Applications/Pd.app/Contents/Resources/extra/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 An attempt to build STK instruments as pd objects, based on https://ccrma.stanford.edu/realsimple/stkforpd/
+
+After autoconfig stuff Flext compiled with:
+
+$ ./configure --enable-system=pd --with-sdkdir=/Applications/Pd.app/Contents/Resources/include/ --with-stkdir=/usr/local/include/stk/

--- a/clarinet.cpp
+++ b/clarinet.cpp
@@ -52,9 +52,9 @@ protected:
         // This function must be defined for any flext object that
         // processes signals at the audio rate.
 	virtual void m_signal(int n, float *const *in, float *const *out);
-	Instrmnt *inst;
-	Effect *effect;
-	BiQuad filter;
+	stk::Instrmnt *inst;
+	stk::Effect *effect;
+	stk::BiQuad filter;
 private:
 	float frequency;
 	float volume;
@@ -127,12 +127,12 @@ bool clarinet::NewObjs()
 	// set up objects
 	try {
 	  // Either instantiate an instrument or an effect
-	  inst = new Clarinet(frequency);	
+	  inst = new clarinet(frequency);	
 	  inst->noteOn(frequency,0.2);		
 	  //effect=new Echo(44100*3);
 	  //((Echo*)effect)->setDelay(1000);
 	}
-	catch (StkError &) {
+	catch (stk::StkError &) {
 		post("%s - Clarinet() setup failed!",thisName());
 		ok = false;
 	}

--- a/clarinet.cpp
+++ b/clarinet.cpp
@@ -127,7 +127,7 @@ bool clarinet::NewObjs()
 	// set up objects
 	try {
 	  // Either instantiate an instrument or an effect
-	  inst = new clarinet(frequency);	
+	  //inst = new clarinet(frequency);	
 	  inst->noteOn(frequency,0.2);		
 	  //effect=new Echo(44100*3);
 	  //((Echo*)effect)->setDelay(1000);


### PR DESCRIPTION
getting:

 ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [pd-darwin/clarinet~.pd_darwin] Error 1

after recompiled flext w stk support using ./configure --enable-system=pd --with-sdkdir=/Applications/Pd.app/Contents/Resources/include/ --with-stkdir=/usr/local/include/stk/